### PR TITLE
Added support for Attiny85

### DIFF
--- a/EasyHID.cpp
+++ b/EasyHID.cpp
@@ -20,6 +20,10 @@ void EasyHID::begin(void) {
   pinMode(3, INPUT);
   pinMode(4, INPUT);
 
+#elif defined(__AVR_ATtiny85__)
+  pinMode(3, INPUT);
+  pinMode(4, INPUT);
+
 #elif (defined(__AVR_ATmega48P__) || defined(__AVR_ATmega88P__) ||  \
        defined(__AVR_ATmega168P__) || defined(__AVR_ATmega168__) || \
        defined(__AVR_ATmega328P__)) ||                              \

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - ATtiny88 (плата MH-ET) **работает через USB на плате!**
 - ATtiny167 (плата Digispark PRO) **работает через USB на плате!**
 - ATtiny48
+- ATtiny85 (D- на PB3, D+ на PB4)
 
 #### Важные моменты
 - Библиотека конфликтует со встроенными функциями `attachInterrupt()` и `detachInterrupt()`, см. пример *MultimediaRemote*

--- a/README_EN.md
+++ b/README_EN.md
@@ -18,6 +18,7 @@ Library for the software implementation of the USB keyboard and mouse on some AV
 - Attiny88 (MH -T-ST) ** works through USB on the board! **
 - Attiny167 (Digispark Pro) ** works through USB on the board! **
 - Attiny48
+- Attiny85 (D- on PB3, D+ on PB4)
 
 #### Important points
 - The library conflicts with built -in functions `Attachinterept ()` and `Detachinterrapt ()`, see example *Multimediaramote *

--- a/usbconfig.h
+++ b/usbconfig.h
@@ -18,6 +18,13 @@
 #define USB_CFG_DMINUS_BIT     		3   	// (D-) = PD1	
 #define USB_CFG_DPLUS_BIT      		6		// (D+) = PD2 (INT0)
 
+/* Micronucleus */
+#elif defined (__AVR_ATtiny85__)
+#define USB_CFG_IOPORTNAME     		B		// PORTB
+#define USB_CFG_DMINUS_BIT     		3   	// (D-) = PB3	
+#define USB_CFG_DPLUS_BIT      		4		// (D+) = PB4
+
+
 
 /* ATmega48p...ATmega328p - Arduino платы и голые камни */
 #elif (defined (__AVR_ATmega48P__) || defined (__AVR_ATmega88P__) ||  \
@@ -343,6 +350,18 @@ defined (__AVR_ATmega328P__) || defined (__AVR_ATmega328__))
 * which is not fully supported (such as IAR C) or if you use a differnt
 * interrupt than INT0, you may have to define some of these.
 */
+
+#if defined (__AVR_ATtiny85__)
+#define USB_INTR_CFG            PCMSK
+#define USB_INTR_CFG_SET        (1 << USB_CFG_DPLUS_BIT)
+#define USB_INTR_CFG_CLR        0
+#define USB_INTR_ENABLE         GIMSK
+#define USB_INTR_ENABLE_BIT     PCIE
+#define USB_INTR_PENDING        GIFR
+#define USB_INTR_PENDING_BIT    PCIF
+#define USB_INTR_VECTOR         PCINT0_vect
+
+#else
 //#define USB_INTR_CFG            MCUCR */
 //#define USB_INTR_CFG_SET        ((1 << ISC00) | (1 << ISC01)) */
 //#define USB_INTR_CFG_CLR        0 */
@@ -351,5 +370,7 @@ defined (__AVR_ATmega328P__) || defined (__AVR_ATmega328__))
 //#define USB_INTR_PENDING        GIFR */
 //#define USB_INTR_PENDING_BIT    INTF0 */
 #define USB_INTR_VECTOR 		  INT0_vect
+
+#endif
 
 #endif /* __usbconfig_h_included__ */


### PR DESCRIPTION
Added support for Digispark and custom Attiny85 boards. D- and D+ pins are on PB3 and PB4 respectively to support Micronucleus (<https://github.com/SpenceKonde/ATTinyCore/blob/v2.0.0-devThis-is-the-head-submit-PRs-against-this/avr/extras/Ref_Micronucleus.md>)

Tested on this tiny custom board:
![pic](https://github.com/user-attachments/assets/d445dbae-09c1-4e7e-a93b-c7f25f324983)
![image](https://github.com/user-attachments/assets/f981b8cc-9899-4ae5-9ac7-814daa23625c)


and this code:

```cpp
#include <EasyHID.h>

bool button_flag = 0;
void setup()
{
  pinMode(2, INPUT);
}

void loop()
{
  if (digitalRead(2) == 0 && button_flag == 0)
  {
    HID.begin();
    button_flag = 1;

    Keyboard.click(KEY_LEFT_GUI, KEY_R);
    unsigned long start = millis();
    while (millis() <= start + 1000)
    {
      HID.tick();
    }
    Keyboard.print("cmd");
    start = millis();
    while (millis() <= start + 1000)
    {
      HID.tick();
    }
    Keyboard.click(KEY_ENTER);
    start = millis();
    while (millis() <= start + 2000)
    {
      HID.tick();
    }
    Keyboard.print("start https://www.linkedin.com/in/behruzerkinov/");
    Keyboard.click(KEY_ENTER);
    HID.end();
  }
  else if (digitalRead(2) == 1 && button_flag == 1)
  {
    button_flag = 0;
  }
}
